### PR TITLE
correct issue with sampler method mixed

### DIFF
--- a/crime_sim_toolkit/poisson_sim.py
+++ b/crime_sim_toolkit/poisson_sim.py
@@ -258,7 +258,7 @@ class Poisson_sim:
             # prep data for linear model
 
             # get years as the X variable
-            x_Years = narrow_frame['Year'].values.reshape(-1,1)
+            x_Years = narrow_frame['Year'].values.reshape(-1, 1)
 
             # get counts as the Y variable
             y_Counts = narrow_frame['Counts'].values
@@ -267,10 +267,10 @@ class Poisson_sim:
             model = linReg().fit(x_Years, y_Counts)
 
             # predict the counts for the next year
-            lin_count = round(np.asscalar(model.predict(np.array([x_Years[-1]+1]))),0)
+            lin_count = round(np.asscalar(model.predict(np.array([x_Years[-1] + 1]))),0)
 
             # calculate the mean of linear and poisson counts
-            mixed_val = round(np.mean(lin_count, poi_count), 0)
+            mixed_val = round(np.mean([lin_count, poi_count]), 0)
 
             return mixed_val
 

--- a/crime_sim_toolkit/tests/test_all.py
+++ b/crime_sim_toolkit/tests/test_all.py
@@ -263,6 +263,42 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(self.poi_data.Day.unique()), 31)
 
+    def test_sampler_day(self):
+        """
+        Test for checking the output of the poisson sampler is as expected
+        when sampling using days
+        """
+
+        self.oobdata = pd.read_csv(pkg_resources.resource_filename(resource_package, 'tests/testing_data/test_oobDay_data.csv'))
+
+        self.traindata = pd.read_csv(pkg_resources.resource_filename(resource_package, 'tests/testing_data/test_trainDay_data.csv'))
+
+        self.poi_data = self.poisson_day.SimplePoission(train_data = self.traindata, test_data = self.oobdata, method = 'zero')
+
+        self.assertTrue(isinstance(self.poi_data, pd.DataFrame))
+
+        self.assertEqual(self.poi_data.columns.tolist(), ['Day','Mon','Crime_type','Counts','LSOA_code','Year'])
+
+        self.assertEqual(len(self.poi_data.Day.unique()), 31)
+
+    def test_sampler_day(self):
+        """
+        Test for checking the output of the poisson sampler is as expected
+        when sampling using days
+        """
+
+        self.oobdata = pd.read_csv(pkg_resources.resource_filename(resource_package, 'tests/testing_data/test_oobDay_data.csv'))
+
+        self.traindata = pd.read_csv(pkg_resources.resource_filename(resource_package, 'tests/testing_data/test_trainDay_data.csv'))
+
+        self.poi_data = self.poisson_day.SimplePoission(train_data = self.traindata, test_data = self.oobdata, method = 'mixed')
+
+        self.assertTrue(isinstance(self.poi_data, pd.DataFrame))
+
+        self.assertEqual(self.poi_data.columns.tolist(), ['Day','Mon','Crime_type','Counts','LSOA_code','Year'])
+
+        self.assertEqual(len(self.poi_data.Day.unique()), 31)
+
     @patch('matplotlib.pyplot.show')
     def test_sampler_error(self, mock_show):
         """


### PR DESCRIPTION
issue found with 

```
Poisson_sim.SimplePoission(train_data = self.traindata, test_data = self.oobdata, method = 'mixed')
```

where np.mean gave error. Values needed to be passed as list.