### PR TITLE
Develop util peturb

### DIFF
--- a/crime_sim_toolkit/tests/test_all.py
+++ b/crime_sim_toolkit/tests/test_all.py
@@ -480,7 +480,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(self.poi_data.shape[0], 14 * 6)
 
-<<<<<<< HEAD
     def test_moving_window_week(self):
 
         self.week = 4
@@ -520,8 +519,6 @@ class Test(unittest.TestCase):
                                       "2016-12-30"]
                                       )
 
-=======
->>>>>>> 8122df2d303d161d34b88de91fa95d158de8d556
     def test_sample_perturb(self):
         """
         Test that adding zero function works
@@ -537,9 +534,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(self.testneg.loc[4,'Counts'], 10)
 
-<<<<<<< HEAD
 
-=======
->>>>>>> 8122df2d303d161d34b88de91fa95d158de8d556
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/crime_sim_toolkit/tests/test_all.py
+++ b/crime_sim_toolkit/tests/test_all.py
@@ -519,6 +519,21 @@ class Test(unittest.TestCase):
                                       "2016-12-30"]
                                       )
 
+    def test_sample_perturb(self):
+        """
+        Test that adding zero function works
+        """
+        self.data = pd.read_csv(pkg_resources.resource_filename(resource_package, 'tests/testing_data/test_sample_perturb.csv'),
+                                    index_col=False)
+
+        self.testpos = utils.sample_perturb(self.data, crime_type='Anti-social behaviour', pct_change=1.1)
+
+        self.testneg = utils.sample_perturb(self.data, crime_type='Violence and sexual offences', pct_change=0.666)
+
+        self.assertEqual(self.testpos.loc[0,'Counts'], 11)
+
+        self.assertEqual(self.testneg.loc[4,'Counts'], 10)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/crime_sim_toolkit/tests/testing_data/test_sample_perturb.csv
+++ b/crime_sim_toolkit/tests/testing_data/test_sample_perturb.csv
@@ -1,0 +1,7 @@
+datetime,LSOA_code,Crime_type,Counts
+2017-01-01,E01010568,Anti-social behaviour,10
+2017-01-01,E01010568,Other crime,2
+2017-01-01,E01010568,Violence and sexual offences,22
+2017-01-01,E01010568,Robbery,4
+2017-01-03,E01010568,Violence and sexual offences,15
+2017-01-03,E01010568,Anti-social behaviour,4

--- a/crime_sim_toolkit/utils.py
+++ b/crime_sim_toolkit/utils.py
@@ -200,5 +200,8 @@ def sample_perturb(counts_frame, crime_type, pct_change):
                                crime counts for specific crime type
     """
 
+    new_counts_frame = counts_frame.copy()
 
-    return
+    new_counts_frame = new_counts_frame.apply(lambda x: round(x.Counts * pct_change,0) if x.Crime_type.isin([crime_type]))
+
+    return new_counts_frame

--- a/crime_sim_toolkit/utils.py
+++ b/crime_sim_toolkit/utils.py
@@ -186,3 +186,19 @@ def validate_datetime(passed_dataframe):
     validated_date_frame = passed_dataframe.copy()
 
     return validated_date_frame
+
+def sample_perturb(counts_frame, crime_type, pct_change):
+    """
+    Utility function to increase the counts of specific crime types
+    after sampling by a given percentage.
+    Inputs : counts_frame, the counts of crime dataframe produced by sampler
+             crime_type, string of crime type that we want to increase
+                         counts for
+             pct_change, the percentage change (negative or positive) of crime
+                         counts desired.
+    Outputs: new_counts_frame, identical dataframe passed but with increased
+                               crime counts for specific crime type
+    """
+
+
+    return

--- a/crime_sim_toolkit/utils.py
+++ b/crime_sim_toolkit/utils.py
@@ -202,6 +202,10 @@ def sample_perturb(counts_frame, crime_type, pct_change):
 
     new_counts_frame = counts_frame.copy()
 
-    new_counts_frame = new_counts_frame.apply(lambda x: round(x.Counts * pct_change,0) if x.Crime_type.isin([crime_type]))
+    mask = (new_counts_frame.Crime_type == crime_type)
+
+    mask_frame = new_counts_frame[mask]
+
+    new_counts_frame.loc[mask,'Counts'] = round(mask_frame.Counts * pct_change, 0)
 
     return new_counts_frame


### PR DESCRIPTION
Added utils.sample_perturb that allows for under/over sampling specific Crime_type (only works on broad crime_types) in reference to issue #7 